### PR TITLE
update license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"keywords":["search","root pages","search engine"],
 	"type":"contao-module",
 	"homepage":"http://www.men-at-work.de",
-	"license":"LGPL-3.0+",
+	"license":"LGPL-3.0-or-later",
 	"authors":[
 		{
 			"name":"Andreas Isaak",


### PR DESCRIPTION
The license information must be SPDX compliant. Otherwise packagist will refuse to auto update. As you can see the two most recent release tags are not updated to packagist currently: https://packagist.org/packages/menatwork/rootsearch

This does not need to be tagged with a new release tag. It just needs to be changed in the master branch.